### PR TITLE
feat: base class for octopus cases

### DIFF
--- a/src/virtual_field/runtime/mode_base.py
+++ b/src/virtual_field/runtime/mode_base.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+from typing import Protocol
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import Any, final
 
-from dataclasses import dataclass, field
+from loguru import logger
 import numpy as np
+from math import cos, pi, sin
 
+from virtual_field.core.commands import ArmCommand, MultiArmCommand
 from virtual_field.core.state import ArmState, MeshEntity, SphereEntity, Transform
-from virtual_field.core.commands import ArmCommand
 from virtual_field.runtime.orientation import (
     compose_rowwise_directors,
     controller_quat_xyzw_to_matrix,
@@ -15,24 +18,24 @@ from virtual_field.runtime.orientation import (
     matrix_to_quat_xyzw,
 )
 
+
+class Rod(Protocol):
+    position_collection: np.ndarray
+    radius: np.ndarray
+    lengths: np.ndarray
+    director_collection: np.ndarray
+
+
+@dataclass(slots=True, kw_only=True)
 class SimulationBase(ABC):
-    pass
+    """Shared backend contract and rod-state helpers for simulation modes."""
 
-@dataclass(slots=True)
-class DualArmSimulationBase(SimulationBase, ABC):
-    """Common control/state helpers shared by dual-arm runtime modes."""
-
-    # Parameters
     user_id: str
-    arm_ids: tuple[str, str]
-    base_left: list[float]
-    base_right: list[float]
-
-    # State
+    arm_ids: tuple[str, ...]
+    arm_bases: dict[str, list[float]] = field(init=False)
     simulator: Any = field(init=False)
     timestepper: Any = field(init=False)
-    left_rod: Any = field(init=False)
-    right_rod: Any = field(init=False)
+    rods: dict[str, Any] = field(init=False, default_factory=dict)
     dt_internal: float = 1.0e-4
     _time: float = field(init=False, default=0.0)
     _last_log_time: float = field(init=False, default=0.0)
@@ -46,89 +49,76 @@ class DualArmSimulationBase(SimulationBase, ABC):
 
     @final
     def __post_init__(self) -> None:
+        self.configure_arm_bases()
         self.build_simulation()
-        self._initialize_dual_arm_targets()
+        self._initialize_arm_targets()
         self.post_mode_setup()
+
+    # --- Abstract / Override following methods ---
+
+    @abstractmethod
+    def configure_arm_bases(self) -> None:
+        """Populate ``self.arm_bases`` before building the simulation."""
 
     @abstractmethod
     def build_simulation(self) -> None:
-        """Build the elastica simulation and initialize simulator and rods."""
+        """Build the simulation and populate ``self.rods``."""
 
     def post_mode_setup(self) -> None:
-        """Optional hook for advanced subclasses after base target setup."""
-        return None
+        pass
 
+    def handle_frame_command(self, command: MultiArmCommand) -> None:
+        pass
+
+    @abstractmethod
     def handle_commands(
         self,
         arm_id: str,
         controller_command: ArmCommand,
         previous_controller_command: ArmCommand | None = None,
     ) -> None:
-        """
-        Handle controller commands for a given arm.
-        Override this method to customize the controller command mapping.
-        """
-        primary_pressed = bool(controller_command.buttons.get("primary", False))
-        secondary_pressed = bool(controller_command.buttons.get("secondary", False))
-        previous_secondary_pressed = bool(
-            previous_controller_command
-            and previous_controller_command.buttons.get("secondary", False)
-        )
+        """Handle controller input for a single arm.
 
-        self.set_attached(arm_id, not (primary_pressed or secondary_pressed))
-        if secondary_pressed and not previous_secondary_pressed:
-            self.reset_target_to_rest(arm_id)
-            self.recalibrate_orientation_to_base(
-                arm_id, controller_command.target.rotation_xyzw
-            )
-            return
-
-        self.set_target_pose(
-            arm_id=arm_id,
-            translation=controller_command.target.translation,
-            rotation_xyzw=controller_command.target.rotation_xyzw,
-        )
+        Subclasses are expected to interpret controller buttons and target pose
+        updates in a mode-appropriate way.
+        """
+        raise NotImplementedError
 
     def handle_command_inactive(self, arm_id: str) -> None:
-        """
-        Reset per-frame controller-driven state for an arm when no command arrives.
-        """
         self.set_attached(arm_id, True)
 
-    def _initialize_dual_arm_targets(self) -> None:
-        left_tip_position = self.left_rod.position_collection[:, -1].copy()
-        right_tip_position = self.right_rod.position_collection[:, -1].copy()
-        left_tip_orientation = self.left_rod.director_collection[..., -1].copy()
-        right_tip_orientation = self.right_rod.director_collection[..., -1].copy()
+    # ---
 
-        self._target_position = {
-            self.arm_ids[0]: left_tip_position.copy(),
-            self.arm_ids[1]: right_tip_position.copy(),
-        }
-        self._target_orientation = {
-            self.arm_ids[0]: left_tip_orientation.copy(),
-            self.arm_ids[1]: right_tip_orientation.copy(),
-        }
-        self._rest_target_position = {
-            self.arm_ids[0]: left_tip_position.copy(),
-            self.arm_ids[1]: right_tip_position.copy(),
-        }
-        self._rest_target_orientation = {
-            self.arm_ids[0]: left_tip_orientation.copy(),
-            self.arm_ids[1]: right_tip_orientation.copy(),
-        }
-        self._base_orientation = {
-            self.arm_ids[0]: self.left_rod.director_collection[..., 0].copy(),
-            self.arm_ids[1]: self.right_rod.director_collection[..., 0].copy(),
-        }
-        self._controller_orientation_offset = {
-            self.arm_ids[0]: np.eye(3, dtype=np.float64),
-            self.arm_ids[1]: np.eye(3, dtype=np.float64),
-        }
-        self._attached = {
-            self.arm_ids[0]: True,
-            self.arm_ids[1]: True,
-        }
+    def _initialize_arm_targets(self) -> None:
+        self._target_position = {}
+        self._target_orientation = {}
+        self._rest_target_position = {}
+        self._rest_target_orientation = {}
+        self._base_orientation = {}
+        self._controller_orientation_offset = {}
+        self._attached = {}
+
+        for arm_id in self.arm_ids:
+            rod = self.rods[arm_id]
+            tip_position = np.asarray(
+                rod.position_collection[:, -1], dtype=np.float64
+            ).copy()
+            tip_orientation = np.asarray(
+                rod.director_collection[..., -1], dtype=np.float64
+            ).copy()
+            base_orientation = np.asarray(
+                rod.director_collection[..., 0], dtype=np.float64
+            ).copy()
+
+            self._target_position[arm_id] = tip_position.copy()
+            self._target_orientation[arm_id] = tip_orientation.copy()
+            self._rest_target_position[arm_id] = tip_position.copy()
+            self._rest_target_orientation[arm_id] = tip_orientation.copy()
+            self._base_orientation[arm_id] = base_orientation
+            self._controller_orientation_offset[arm_id] = np.array(
+                [[1, 0, 0], [0, 0, 1], [0, -1, 0]], dtype=np.float64
+            )  # Arm-forward quaternion to row-wise orientation
+            self._attached[arm_id] = True
 
     def set_target_pose(
         self, arm_id: str, translation: list[float], rotation_xyzw: list[float]
@@ -152,41 +142,34 @@ class DualArmSimulationBase(SimulationBase, ABC):
     ) -> None:
         if arm_id not in self._controller_orientation_offset:
             return
-        controller_orientation = controller_quat_xyzw_to_matrix(controller_rotation_xyzw)
-        self._controller_orientation_offset[arm_id] = compose_rowwise_directors(
+        controller_orientation = controller_quat_xyzw_to_matrix(
+            controller_rotation_xyzw
+        )
+        tt = compose_rowwise_directors(
             self._base_orientation[arm_id],
             invert_rowwise_director(controller_orientation),
         )
+        logger.debug(
+            "Recalibrated arm {} orientation offset={}",
+            arm_id,
+            np.round(tt, decimals=6).tolist(),
+        )
+        self._controller_orientation_offset[arm_id] = tt
 
-    # Controller Query Methods
-    def _target_for_arm(self, arm_id: str) -> tuple[np.ndarray, np.ndarray]:
+    def target_for_arm(self, arm_id: str) -> tuple[np.ndarray, np.ndarray]:
         return (
             self._target_position[arm_id],
             self._target_orientation[arm_id],
         )
 
-    def get_target_left(self) -> tuple[np.ndarray, np.ndarray]:
-        return self._target_for_arm(self.arm_ids[0])
-
-    def get_target_right(self) -> tuple[np.ndarray, np.ndarray]:
-        return self._target_for_arm(self.arm_ids[1])
-
-    def _is_arm_attached(self, arm_id: str) -> bool:
+    def is_arm_attached(self, arm_id: str) -> bool:
         return self._attached[arm_id]
 
-    def is_left_attached(self) -> bool:
-        return self._is_arm_attached(self.arm_ids[0])
-
-    def is_right_attached(self) -> bool:
-        return self._is_arm_attached(self.arm_ids[1])
-
-    # Controller-driven actions
     def set_attached(self, arm_id: str, attached: bool) -> None:
         if arm_id not in self._attached:
             return
         self._attached[arm_id] = attached
 
-    # Simulation Stepping
     def step(self, dt: float) -> None:
         total = max(0.0, dt)
         if total <= 0.0:
@@ -198,25 +181,32 @@ class DualArmSimulationBase(SimulationBase, ABC):
         if self._time - self._last_log_time >= 0.1:
             self._last_log_time = self._time
 
-    # Asset Publishing
+    def arm_states(self) -> dict[str, ArmState]:
+        return {
+            arm_id: self._rod_to_arm_state(arm_id, self.rods[arm_id])
+            for arm_id in self.arm_ids
+        }
+
     def mesh_entities(self) -> list[MeshEntity]:
         return []
 
     def sphere_entities(self) -> list[SphereEntity]:
         return []
 
-    def arm_states(self) -> dict[str, ArmState]:
-        return {
-            self.arm_ids[0]: self._rod_to_arm_state(self.arm_ids[0], self.left_rod),
-            self.arm_ids[1]: self._rod_to_arm_state(self.arm_ids[1], self.right_rod),
-        }
-
-    def _rod_to_arm_state(self, arm_id: str, rod: object) -> ArmState:
-        positions = np.asarray(rod.position_collection, dtype=np.float64)
+    def _rod_to_arm_state(self, arm_id: str, rod: Rod) -> ArmState:
+        """
+        Convert a rod to an arm state.
+        Used to publish the arm state to the client.
+        """
+        node_slice = self._rod_slice_or_full(rod, "_active_node_slice")
+        elem_slice = self._rod_slice_or_full(rod, "_active_elem_slice")
+        positions = np.asarray(rod.position_collection[:, node_slice], dtype=np.float64)
         centerline = positions.T.tolist()
-        radii = np.asarray(rod.radius, dtype=np.float64).tolist()
-        element_lengths = self._rod_element_lengths(rod)
-        directors = np.asarray(rod.director_collection, dtype=np.float64)
+        radii = np.asarray(rod.radius[elem_slice], dtype=np.float64).tolist()
+        element_lengths = np.asarray(rod.lengths[elem_slice], dtype=np.float64).tolist()
+        directors = np.asarray(
+            rod.director_collection[:, :, elem_slice], dtype=np.float64
+        )
         directors_list = [
             directors[..., elem_idx].tolist() for elem_idx in range(directors.shape[-1])
         ]
@@ -243,11 +233,115 @@ class DualArmSimulationBase(SimulationBase, ABC):
             contact_points=self.contact_points_for_arm(arm_id),
         )
 
-    def _rod_element_lengths(self, rod: object) -> list[float]:
-        lengths = getattr(rod, "lengths", None)
-        if lengths is None:
-            return []
-        return np.asarray(lengths, dtype=np.float64).tolist()
-
     def contact_points_for_arm(self, arm_id: str) -> list[list[float]]:
         return []
+
+    def _rod_slice_or_full(self, rod: Rod, method_name: str) -> slice:
+        method = getattr(rod, method_name, None)
+        if callable(method):
+            return method()
+        return slice(None)
+
+
+@dataclass(slots=True, kw_only=True)
+class DualArmSimulationBase(SimulationBase, ABC):
+    """Simulation base specialized for a left/right pair of arms."""
+
+    base_left: list[float]
+    base_right: list[float]
+
+    def configure_arm_bases(self) -> None:
+        self.arm_bases = {
+            self.arm_ids[0]: self.base_left,
+            self.arm_ids[1]: self.base_right,
+        }
+
+    def handle_commands(
+        self,
+        arm_id: str,
+        controller_command: ArmCommand,
+        previous_controller_command: ArmCommand | None = None,
+    ) -> None:
+        primary_pressed = bool(controller_command.buttons.get("primary", False))
+        secondary_pressed = bool(controller_command.buttons.get("secondary", False))
+        previous_secondary_pressed = bool(
+            previous_controller_command
+            and previous_controller_command.buttons.get("secondary", False)
+        )
+
+        self.set_attached(arm_id, not (primary_pressed or secondary_pressed))
+        if secondary_pressed and not previous_secondary_pressed:
+            self.reset_target_to_rest(arm_id)
+            self.recalibrate_orientation_to_base(
+                arm_id, controller_command.target.rotation_xyzw
+            )
+            return
+
+        self.set_target_pose(
+            arm_id=arm_id,
+            translation=controller_command.target.translation,
+            rotation_xyzw=controller_command.target.rotation_xyzw,
+        )
+
+    @property
+    def left_rod(self) -> Any:
+        return self.rods[self.arm_ids[0]]
+
+    @left_rod.setter
+    def left_rod(self, rod: Any) -> None:
+        self.rods[self.arm_ids[0]] = rod
+
+    @property
+    def right_rod(self) -> Any:
+        return self.rods[self.arm_ids[1]]
+
+    @right_rod.setter
+    def right_rod(self, rod: Any) -> None:
+        self.rods[self.arm_ids[1]] = rod
+
+    def get_target_left(self) -> tuple[np.ndarray, np.ndarray]:
+        return self.target_for_arm(self.arm_ids[0])
+
+    def get_target_right(self) -> tuple[np.ndarray, np.ndarray]:
+        return self.target_for_arm(self.arm_ids[1])
+
+    def is_left_attached(self) -> bool:
+        return self.is_arm_attached(self.arm_ids[0])
+
+    def is_right_attached(self) -> bool:
+        return self.is_arm_attached(self.arm_ids[1])
+
+
+@dataclass(slots=True, kw_only=True)
+class OctoArmSimulationBase(SimulationBase, ABC):
+    """Simulation base specialized for a fixed eight-arm layout."""
+
+    base_position: tuple[float, float, float] | tuple[list[float], ...]
+
+    arm_radial_spacing: float = 0.05
+
+    def configure_arm_bases(self) -> None:
+        if len(self.base_position) == len(self.arm_ids) and isinstance(
+            self.base_position[0], (list, tuple)
+        ):
+            self.arm_bases = {
+                arm_id: list(self.base_position[index])
+                for index, arm_id in enumerate(self.arm_ids)
+            }
+            return
+
+        base_x, base_y, base_z = self.base_position
+
+        def _base_position(index: int) -> tuple[float, float, float]:
+            loc = index / 8.0
+            offset_angle = np.deg2rad(22.5)
+            translation = (
+                base_x - self.arm_radial_spacing * cos(offset_angle + 2.0 * pi * loc),
+                base_y,
+                base_z + self.arm_radial_spacing * sin(offset_angle + 2.0 * pi * loc),
+            )
+            return translation
+
+        self.arm_bases = {
+            arm_id: _base_position(index) for index, arm_id in enumerate(self.arm_ids)
+        }

--- a/src/virtual_field/runtime/mode_registry.py
+++ b/src/virtual_field/runtime/mode_registry.py
@@ -1,20 +1,62 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
-from virtual_field.runtime.mode_base import SimulationBase
+# from virtual_field.runtime.cathy_foraging_simulation import CathyForagingSimulation
 from virtual_field.runtime.cathy_throw_simulation import CathyThrowSimulation
+from virtual_field.runtime.coomm_octopus_simulation import COOMMOctopusSimulation
+from virtual_field.runtime.mode_base import SimulationBase
+from virtual_field.runtime.noel_c4_simulation import NoelC4Simulation
+# from virtual_field.runtime.octo_waypoint_simulation import OctoWaypointSimulation
+# from virtual_field.runtime.spirobs_simulation import SpirobsSimulation
 from virtual_field.runtime.two_cr_simulation import TwoCRSimulation
+from virtual_field.runtime.two_gcr_simulation import TwoGCRSimulation
 
-SimulationFactory = Callable[..., object]
+SimulationFactory = Callable[..., SimulationBase]
 
-# Add new mode here:
-SIMULATION_FACTORIES: dict[str, SimulationFactory] = {
-    "two-cr": TwoCRSimulation,
-    "cathy-throw": CathyThrowSimulation,
-}
+
+@dataclass(frozen=True, slots=True)
+class CharacterModeSpec:
+    """Describes the configuration for a character mode.
+
+    Attributes
+    ----------
+    arm_count : int
+        Number of arms (effectors) the character has in this mode.
+    base_layout : str
+        Base layout style; typically 'linear' or 'octo'.
+    factory : SimulationFactory | None, optional
+        Optional class that produces a SimulationBase instance for this mode.
+        If None, no specialized simulation logic is used.
+    """
+    arm_count: int
+    base_layout: str
+    factory: SimulationFactory | None = None
+
 
 DEFAULT_CHARACTER_MODE = "demo-spline"
-SUPPORTED_CHARACTER_MODES = frozenset(
-    [DEFAULT_CHARACTER_MODE, *SIMULATION_FACTORIES.keys()]
-)
+MODE_SPECS: dict[str, CharacterModeSpec] = {
+    DEFAULT_CHARACTER_MODE: CharacterModeSpec(arm_count=2, base_layout="linear"),
+    "two-cr": CharacterModeSpec(arm_count=2, base_layout="linear", factory=TwoCRSimulation),
+    "two-gcr": CharacterModeSpec(arm_count=2, base_layout="linear", factory=TwoGCRSimulation),
+    # "spirobs": CharacterModeSpec(arm_count=2, base_layout="linear", factory=SpirobsSimulation),
+    "cathy-throw": CharacterModeSpec(
+        arm_count=2, base_layout="linear", factory=CathyThrowSimulation
+    ),
+    "coomm-octopus": CharacterModeSpec(
+        arm_count=2, base_layout="linear", factory=COOMMOctopusSimulation
+    ),
+    "noel-c4": CharacterModeSpec(arm_count=2, base_layout="linear", factory=NoelC4Simulation),
+    # "cathy-foraging": CharacterModeSpec(
+    #     arm_count=8, base_layout="octo", factory=CathyForagingSimulation
+    # ),
+    # "octo-waypoint": CharacterModeSpec(
+    #     arm_count=9, base_layout="octo", factory=OctoWaypointSimulation
+    # ),
+}
+SUPPORTED_CHARACTER_MODES = frozenset(MODE_SPECS.keys())
+
+
+def get_mode_spec(character_mode: str) -> CharacterModeSpec:
+    return MODE_SPECS.get(character_mode, MODE_SPECS[DEFAULT_CHARACTER_MODE])


### PR DESCRIPTION
### TL;DR

Refactored simulation base classes to support variable numbers of arms and added a mode registry system with character mode specifications.

### What changed?

- Converted `SimulationBase` from a simple ABC to a dataclass with shared rod-state helpers and abstract methods for configuration
- Replaced dual-arm specific logic in `SimulationBase` with generic multi-arm support using dictionaries keyed by arm ID
- Created `DualArmSimulationBase` as a specialized subclass that maintains backward compatibility for two-arm scenarios
- Added `OctoArmSimulationBase` for eight-arm configurations with radial positioning
- Introduced `Rod` protocol to define the interface for rod objects
- Added `CharacterModeSpec` dataclass to describe character mode configurations including arm count and base layout
- Replaced simple factory dictionary with comprehensive mode specifications in `MODE_SPECS`
- Added new simulation modes: `two-gcr`, `coomm-octopus`, and `noel-c4`
- Made controller command handling abstract in base class while providing default implementation in `DualArmSimulationBase`

### How to test?

- Verify existing dual-arm simulations (`two-cr`, `cathy-throw`) continue to work as before
- Test the new simulation modes (`two-gcr`, `coomm-octopus`, `noel-c4`) can be instantiated
- Confirm that `get_mode_spec()` returns appropriate specifications for all supported character modes
- Validate that the octo-arm base positioning calculates correct radial coordinates

### Why make this change?

This refactoring enables support for characters with varying numbers of arms (not just dual-arm) while maintaining backward compatibility. The mode registry system provides a cleaner way to manage different character configurations and their associated simulation factories, making it easier to add new character types in the future.