### PR TITLE
Fix minor bug to render the scene for COOMM

### DIFF
--- a/src/virtual_field/runtime/coomm_octopus_simulation.py
+++ b/src/virtual_field/runtime/coomm_octopus_simulation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
+import elastica as ea
 import numpy as np
 from collections import deque
 
@@ -13,6 +14,8 @@ from virtual_field.core.state import SphereEntity
 @dataclass(slots=True)
 class COOMMOctopusSimulation(DualArmSimulationBase):
     """COOMM Octopus mode"""
+
+    _sphere: list[ea.Sphere] = field(init=False)
 
     def build_simulation(self) -> None:
         import elastica as ea
@@ -67,6 +70,13 @@ class COOMMOctopusSimulation(DualArmSimulationBase):
         )
         self.simulator.append(self.left_rod)
         self.simulator.append(self.right_rod)
+
+        self._sphere = ea.Sphere(
+            np.array([0.0, 1.0, -0.3]),
+            0.05,
+            100.0,
+        )
+        self.simulator.append(self._sphere)
 
         self.simulator.constrain(self.left_rod).using(
             ea.FixedConstraint,
@@ -123,15 +133,16 @@ class COOMMOctopusSimulation(DualArmSimulationBase):
 
     def sphere_entities(self) -> list[SphereEntity]:
         spheres: list[SphereEntity] = []
-        for idx, sphere in enumerate(self.spheres):
-            position = np.asarray(sphere.position_collection[..., 0], dtype=np.float64)
-            spheres.append(
-                SphereEntity(
-                    sphere_id=f"{self.user_id}_coomm_octopus_sphere_{idx}",
-                    owner_id=self.user_id,
-                    translation=position.tolist(),
-                    radius=float(sphere.radius),
-                    color_rgb=[0.95, 0.62, 0.32],
-                )
+        position = np.asarray(
+            self._sphere.position_collection[..., 0], dtype=np.float64
+        )
+        spheres.append(
+            SphereEntity(
+                sphere_id=f"{self.user_id}_coomm_octopus_sphere",
+                owner_id=self.user_id,
+                translation=position.tolist(),
+                radius=float(self._sphere.radius),
+                color_rgb=[0.95, 0.62, 0.32],
             )
+        )
         return spheres


### PR DESCRIPTION
### TL;DR

Replaced dynamic sphere collection with a single fixed sphere in the COOMM Octopus simulation.

### What changed?

- Added a `_sphere` field to store a single `ea.Sphere` instance
- Created one sphere with position `[0.0, 1.0, -0.3]`, radius `0.05`, and density `100.0`
- Modified `sphere_entities()` method to return only this single sphere instead of iterating through a collection
- Updated sphere ID naming to remove the index suffix since there's now only one sphere

### How to test?

Run the COOMM Octopus simulation and verify that:
- A single sphere appears at the specified position
- The sphere has the correct visual properties (orange color, proper radius)
- No errors occur during simulation initialization or execution

### Why make this change?

This simplifies the sphere management in the simulation by using a single, well-defined sphere rather than maintaining a dynamic collection, which likely improves performance and reduces complexity for this specific use case.